### PR TITLE
Replaced use of React.PropTypes with prop-types package.

### DIFF
--- a/Components/AbilityRow.js
+++ b/Components/AbilityRow.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { Text, View, TouchableOpacity } from 'react-native';
 import StyleSheet from '../Styles/AbilityRow';
 import LabeledNumber from './LabeledNumber';
@@ -28,13 +29,13 @@ const AbilityRow = (props) => {
 };
 
 AbilityRow.propTypes = {
-  ability: React.PropTypes.shape({
-    score: React.PropTypes.number.isRequired,
-    isProficient: React.PropTypes.bool.isRequired,
-    name: React.PropTypes.string.isRequired,
+  ability: PropTypes.shape({
+    score: PropTypes.number.isRequired,
+    isProficient: PropTypes.bool.isRequired,
+    name: PropTypes.string.isRequired,
   }).isRequired,
-  proficiencyBonus: React.PropTypes.number.isRequired,
-  last: React.PropTypes.bool,
+  proficiencyBonus: PropTypes.number.isRequired,
+  last: PropTypes.bool,
 };
 AbilityRow.defaultProps = {
   last: false,

--- a/Components/LabeledNumber.js
+++ b/Components/LabeledNumber.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { Text, View } from 'react-native';
 import StyleSheet from '../Styles/Base';
 
@@ -10,8 +11,8 @@ const LabeledNumber = props => (
 );
 
 LabeledNumber.propTypes = {
-  children: React.PropTypes.node.isRequired,
-  label: React.PropTypes.node.isRequired,
+  children: PropTypes.node.isRequired,
+  label: PropTypes.node.isRequired,
 };
 
 export default LabeledNumber;

--- a/Components/LabeledText.js
+++ b/Components/LabeledText.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { Text, View } from 'react-native';
 import StyleSheet from '../Styles/Base';
 
@@ -10,8 +11,8 @@ const LabeledText = props => (
 );
 
 LabeledText.propTypes = {
-  children: React.PropTypes.node.isRequired,
-  label: React.PropTypes.node.isRequired,
+  children: PropTypes.node.isRequired,
+  label: PropTypes.node.isRequired,
 };
 
 export default LabeledText;

--- a/Components/SkillRow.js
+++ b/Components/SkillRow.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { View } from 'react-native';
 import StyleSheet from '../Styles/SkillRowStyle';
 import LabeledNumber from './LabeledNumber';
@@ -16,11 +17,11 @@ const SkillRow = (props) => {
 };
 
 SkillRow.propTypes = {
-  skill: React.PropTypes.shape({
-    val: React.PropTypes.number,
-    mod: React.PropTypes.number,
-    save: React.PropTypes.number,
-    text: React.PropTypes.string,
+  skill: PropTypes.shape({
+    val: PropTypes.number,
+    mod: PropTypes.number,
+    save: PropTypes.number,
+    text: PropTypes.string,
   }).isRequired,
 };
 

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   },
   "dependencies": {
     "expo": "^19.0.0",
+    "prop-types": "^15.5.10",
     "react": "16.0.0-alpha.12",
     "react-native": "^0.46.1",
     "react-navigation": "^1.0.0-beta.11"


### PR DESCRIPTION
Resolves #17 

Linter was giving the following warning: 
> PropTypes has been moved to a separate package. Accessing React.PropTypes is no longer supported and will be removed completely in React 16. Use the prop-types package on npm instead. 

I followed the instruction here to use the new package instead of the depreciated React.PropTypes: https://fb.me/migrating-from-react-proptypes